### PR TITLE
Add support for message threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ All the events have the same fields as the command input plus error (in case of 
 
     {
         "message": "...", // required
-        "channelId": "..." // required
+        "channelId": "...", // required
+        "threadTimestamp": "..." // optional
     }
 
 Returned events
@@ -45,14 +46,15 @@ Returned events
 
     {
         "message": "...",
-        "channelId": "..."
+        "channelId": "...",
+        "threadTimestamp": "..."
     }
 
 `SendMessageFailed`
 
     {
         "message": "...",
-        "channelId": "..."
+        "channelId": "...",
         "error": "..."
     }
 
@@ -156,7 +158,9 @@ Returned events
             "email": "...",
             "title": "...",      // e.g. Principal Systems Engineer
             "firstName": "...",
-            "lastName": "..."
+            "lastName": "...",
+            "timestamp": "...",
+            "threadTimestamp": "..."
         },
         "message": "..."
     }

--- a/command/message.go
+++ b/command/message.go
@@ -30,8 +30,9 @@ var (
 )
 
 type SendMessageInput struct {
-	Message   string `json:"message"`
-	ChannelId string `json:"channelId"`
+	Message         string `json:"message"`
+	ThreadTimestamp string `json:"threadTimestamp"`
+	ChannelId       string `json:"channelId"`
 }
 
 type SendMessageOutput struct {
@@ -72,7 +73,7 @@ func sendMessageHandler(slack client.Slack) func(json.RawMessage) flyte.Event {
 			return newSendMessageFailedEvent(input.Message, input.ChannelId, strings.Join(errorMessages, ", "))
 		}
 
-		slack.SendMessage(input.Message, input.ChannelId)
+		slack.SendMessage(input.Message, input.ChannelId, input.ThreadTimestamp)
 		return newMessageSentEvent(input.Message, input.ChannelId)
 	}
 }

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -37,7 +37,7 @@ func NewMockSlack() *MockSlack {
 	return m
 }
 
-func (m *MockSlack) SendMessage(message, channelId string) {
+func (m *MockSlack) SendMessage(message, channelId, _ string) {
 	m.SendMessageCalls[channelId] = append(m.SendMessageCalls[channelId], message)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -39,7 +39,7 @@ func TestPackDefinitionIsPopulated(t *testing.T) {
 
 type DummySlack struct{}
 
-func (DummySlack) SendMessage(message, channelId string) {}
+func (DummySlack) SendMessage(message, channelId, threadTimestamp string) {}
 
 func (DummySlack) SendRichMessage(client.RichMessage) error { return nil }
 


### PR DESCRIPTION
Add `timestamp` and `thread timestamp` to message events
Add optional `thread timestamp` to send message command

point is to allow a flow to start or continue a thread...